### PR TITLE
Bugfix/generator npm init dependency

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -7,7 +7,7 @@ module.exports = Base.extend({
   },
   
   initializing: function() {
-    this.composeWith('npm-init', require.resolve('generator-npm-init/app'))
+    this.composeWith(require.resolve('generator-npm-init/app'))
   },
   
   prompting: function() {

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -5,8 +5,9 @@ let fs      = require('fs');
 let helpers = require("yeoman-test");
 let path    = require("path");
 
+let pathToNpmInit = require.resolve('generator-npm-init/app');
 let deps = [
-  [helpers.createDummyGenerator(), 'npm-init:app']
+  [helpers.createDummyGenerator(), pathToNpmInit]
 ]
 
 describe("Main Generator (yo capi)", function(){

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -5,14 +5,18 @@ let fs      = require('fs');
 let helpers = require("yeoman-test");
 let path    = require("path");
 
+let deps = [
+  [helpers.createDummyGenerator(), 'npm-init:app']
+]
+
 describe("Main Generator (yo capi)", function(){
   
   describe("Generic setup", function(){
-    
     let suite = this; 
     
     beforeAll(function(done){
-      helpers.run(path.resolve(__dirname, '../generators/app'))
+      return helpers.run(path.resolve(__dirname, '../generators/app'))
+      .withGenerators(deps)
       .withPrompts({
         projectTitle: "Test Project",
         projectDescription: "This is a test",

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -12,7 +12,6 @@ describe("Main Generator (yo capi)", function(){
     
     beforeAll(function(done){
       return helpers.run(path.resolve(__dirname, '../generators/app'))
-      .withGenerators(deps)
       .withPrompts({
         projectTitle: "Test Project",
         projectDescription: "This is a test",

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -5,10 +5,6 @@ let fs      = require('fs');
 let helpers = require("yeoman-test");
 let path    = require("path");
 
-let deps = [
-  [helpers.createDummyGenerator(), 'npm-init:app']
-]
-
 describe("Main Generator (yo capi)", function(){
   
   describe("Generic setup", function(){

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -5,6 +5,10 @@ let fs      = require('fs');
 let helpers = require("yeoman-test");
 let path    = require("path");
 
+let deps = [
+  [helpers.createDummyGenerator(), 'npm-init:app']
+]
+
 describe("Main Generator (yo capi)", function(){
   
   describe("Generic setup", function(){
@@ -12,6 +16,7 @@ describe("Main Generator (yo capi)", function(){
     
     beforeAll(function(done){
       return helpers.run(path.resolve(__dirname, '../generators/app'))
+      .withGenerators(deps)
       .withPrompts({
         projectTitle: "Test Project",
         projectDescription: "This is a test",

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -5,18 +5,14 @@ let fs      = require('fs');
 let helpers = require("yeoman-test");
 let path    = require("path");
 
-let deps = [
-  [helpers.createDummyGenerator(), 'npm-init:app']
-]
-
 describe("Main Generator (yo capi)", function(){
   
   describe("Generic setup", function(){
+    
     let suite = this; 
     
     beforeAll(function(done){
-      return helpers.run(path.resolve(__dirname, '../generators/app'))
-      .withGenerators(deps)
+      helpers.run(path.resolve(__dirname, '../generators/app'))
       .withPrompts({
         projectTitle: "Test Project",
         projectDescription: "This is a test",


### PR DESCRIPTION
Corrects the path to`generator-npm-init` in both the composeWith call and the spec.  Solves an issue where initial `yo capi` call would fail if `generator-npm-init` was not called globally, as well as fixing tests in the Node 4 environment